### PR TITLE
Fix specification of experimental capabilities

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -145,11 +145,7 @@
             "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
             "properties": {
                 "experimental": {
-                    "additionalProperties": {
-                        "additionalProperties": true,
-                        "properties": {},
-                        "type": "object"
-                    },
+                    "additionalProperties": {},
                     "description": "Experimental, non-standard capabilities that the client supports.",
                     "type": "object"
                 },
@@ -1735,11 +1731,7 @@
             "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
             "properties": {
                 "experimental": {
-                    "additionalProperties": {
-                        "additionalProperties": true,
-                        "properties": {},
-                        "type": "object"
-                    },
+                    "additionalProperties": {},
                     "description": "Experimental, non-standard capabilities that the server supports.",
                     "type": "object"
                 },

--- a/schema/schema.ts
+++ b/schema/schema.ts
@@ -189,7 +189,7 @@ export interface ClientCapabilities {
   /**
    * Experimental, non-standard capabilities that the client supports.
    */
-  experimental?: { [key: string]: object };
+  experimental?: { [key: string]: unknown };
   /**
    * Present if the client supports listing roots.
    */
@@ -212,7 +212,7 @@ export interface ServerCapabilities {
   /**
    * Experimental, non-standard capabilities that the server supports.
    */
-  experimental?: { [key: string]: object };
+  experimental?: { [key: string]: unknown };
   /**
    * Present if the server supports sending log messages to the client.
    */
@@ -814,14 +814,14 @@ export interface Annotated {
   annotations?: {
     /**
      * Describes who the intended customer of this object or data is.
-     * 
+     *
      * It can include multiple entries to indicate content useful for multiple audiences (e.g., `["user", "assistant"]`).
      */
     audience?: Role[];
 
     /**
      * Describes how important this data is for operating the server.
-     * 
+     *
      * A value of 1 means "most important," and indicates that the data is
      * effectively required, while 0 means "least important," and indicates that
      * the data is entirely optional.


### PR DESCRIPTION
The [example python library usage](https://github.com/modelcontextprotocol/python-sdk/blob/e41482821c65e3886f38fd48560bc14a1e53fbbf/src/mcp/server/session.py#L16) assumes `experimental` is eg `{"experimental": {"key": True}}`. Right now I believe the typescript spec and therefore the jsonschema spec forces an additional level of nesting `{"experimental": {"key": {"why": True}}}`: 

https://github.com/modelcontextprotocol/specification/blob/9d3c21d9a9384c080ae7de308a6f8116bbf2c801/schema/schema.ts#L188-L192

as `: object` implies a key:value pair rather than the true `unknown` value (which in python really is `object`).