### PR TITLE
Add array of required properties to inputSchema of Tool

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1987,6 +1987,12 @@
                         "type": {
                             "const": "object",
                             "type": "string"
+                        },
+                        "required": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1984,15 +1984,15 @@
                             },
                             "type": "object"
                         },
-                        "type": {
-                            "const": "object",
-                            "type": "string"
-                        },
                         "required": {
                             "items": {
                                 "type": "string"
                             },
                             "type": "array"
+                        },
+                        "type": {
+                            "const": "object",
+                            "type": "string"
                         }
                     },
                     "required": [

--- a/schema/schema.ts
+++ b/schema/schema.ts
@@ -695,6 +695,7 @@ export interface Tool {
   inputSchema: {
     type: "object";
     properties?: { [key: string]: object };
+    required?: string[];
   };
 }
 


### PR DESCRIPTION
Add list of required properties to json schema of Tool under inputSchema.

## Motivation and Context
inputSchema in Tool has "type" and "properties", but does not seem to have "required", while actual implementations appear to be providing this, f.e: https://github.com/modelcontextprotocol/servers/blob/0ff39c72c618976fb06e5a6be902ffd468f368c0/src/sentry/src/mcp_server_sentry/server.py#L241
https://github.com/modelcontextprotocol/servers/blob/0ff39c72c618976fb06e5a6be902ffd468f368c0/src/sqlite/src/mcp_server_sqlite/server.py#L284

## How Has This Been Tested?
I assume since a bunch of python based servers use this, it is tested there already.

## Breaking Changes
There should not be any, as "required" itself is not required.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] ~~I have added appropriate error handling~~ - not applicable
- [x] I have added or updated documentation as needed

## Additional context
I was trying to make my own server based of existing code, however relying on json schema turned out to be problematic, as it does not always correspond to what actual implementations are doing. This change attempts to fix it.
