### PR TITLE
Fix minor error in roots.md

### DIFF
--- a/docs/specification/client/roots.md
+++ b/docs/specification/client/roots.md
@@ -20,7 +20,7 @@ However, implementations are free to expose roots through any interface pattern 
 
 ## Capabilities
 
-Clients that support prompts **MUST** declare the `roots` capability during [initialization]({{< ref "/specification/basic/lifecycle#initialization" >}}):
+Clients that support roots **MUST** declare the `roots` capability during [initialization]({{< ref "/specification/basic/lifecycle#initialization" >}}):
 
 ```json
 {


### PR DESCRIPTION
There appears to be a minor error in `roots.md`. The spec says:
> Clients that support prompts MUST declare the roots capability during [initialization](https://spec.modelcontextprotocol.io/specification/basic/lifecycle/#initialization):

I believe that the spec should say:
> Clients that support roots MUST declare the roots capability during [initialization](https://spec.modelcontextprotocol.io/specification/basic/lifecycle/#initialization):

## Motivation and Context
spec error

## How Has This Been Tested?
Doc-only change. (Although I validated the changes as per CONTRIBUTING.md.)

## Breaking Changes
No.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
N/A