### PR TITLE
RFC2119 key words in uppercase and bold

### DIFF
--- a/docs/specification/client/roots.md
+++ b/docs/specification/client/roots.md
@@ -67,7 +67,7 @@ To retrieve roots, servers send a `roots/list` request:
 
 ### Root List Changes
 
-When roots change, clients that support `listChanged` MUST send a notification:
+When roots change, clients that support `listChanged` **MUST** send a notification:
 
 ```json
 {
@@ -128,7 +128,7 @@ Example roots for different use cases:
 
 ## Error Handling
 
-Clients SHOULD return standard JSON-RPC errors for common failure cases:
+Clients **SHOULD** return standard JSON-RPC errors for common failure cases:
 
 - Client does not support roots: `-32601` (Method not found)
 - Internal errors: `-32603`

--- a/docs/specification/server/prompts.md
+++ b/docs/specification/server/prompts.md
@@ -211,7 +211,7 @@ Embedded resources enable prompts to seamlessly incorporate server-managed conte
 
 ## Error Handling
 
-Servers SHOULD return standard JSON-RPC errors for common failure cases:
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
 
 - Invalid prompt name: `-32602` (Invalid params)
 - Missing required arguments: `-32602` (Invalid params)

--- a/docs/specification/server/prompts.md
+++ b/docs/specification/server/prompts.md
@@ -187,7 +187,7 @@ Image content allows including visual information in messages:
   "mimeType": "image/png"
 }
 ```
-The image data MUST be base64-encoded and include a valid MIME type. This enables multi-modal interactions where visual context is important.
+The image data **MUST** be base64-encoded and include a valid MIME type. This enables multi-modal interactions where visual context is important.
 
 #### Embedded Resources
 Embedded resources allow referencing server-side resources directly in messages:
@@ -202,7 +202,7 @@ Embedded resources allow referencing server-side resources directly in messages:
 }
 ```
 
-Resources can contain either text or binary (blob) data and MUST include:
+Resources can contain either text or binary (blob) data and **MUST** include:
 - A valid resource URI
 - The appropriate MIME type
 - Either text content or base64-encoded blob data

--- a/docs/specification/server/resources.md
+++ b/docs/specification/server/resources.md
@@ -293,7 +293,7 @@ Git version control integration.
 
 ## Error Handling
 
-Servers SHOULD return standard JSON-RPC errors for common failure cases:
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
 
 - Resource not found: `-32002`
 - Internal errors: `-32603`


### PR DESCRIPTION
## Motivation and Context

In the docs, most RFC2119 keywords (MUST / MUST NOT / SHOULD / SHOULD NOT / ...) are written in uppercase and bold.

A few are not. For consistency, this PR fixes this.

## How Has This Been Tested?

Previews on my fork.

## Breaking Changes

Nope.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context

