### PR TITLE
Adds i18n support

### DIFF
--- a/docs/specification/basic/lifecycle.md
+++ b/docs/specification/basic/lifecycle.md
@@ -64,6 +64,9 @@ The client **MUST** initiate this phase by sending an `initialize` request conta
         "listChanged": true
       },
       "sampling": {}
+      "locale": {
+        "preferredLanguages": ["en-US", "en-GB", "fr-FR"]
+      }
     },
     "clientInfo": {
       "name": "ExampleClient",
@@ -92,6 +95,9 @@ The server **MUST** respond with its own capabilities and information:
       },
       "tools": {
         "listChanged": true
+      },
+      "locale": {
+        "language": "en-US"
       }
     },
     "serverInfo": {
@@ -132,11 +138,13 @@ Key capabilities include:
 |----------|--------------- |-------------|
 | Client   | `roots`        | Ability to provide filesystem [roots]({{< ref "/specification/client/roots" >}}) |
 | Client   | `sampling`     | Support for LLM [sampling]({{< ref "/specification/client/sampling" >}}) requests |
+| Client   | `locale`       | Provides [i18n support]({{< ref "/specification/client/i18n" >}}) |
 | Client   | `experimental` | Describes support for non-standard experimental features |
 | Server   | `prompts`      | Offers [prompt templates]({{< ref "/specification/server/prompts" >}}) |
 | Server   | `resources`    | Provides readable [resources]({{< ref "/specification/server/resources" >}}) |
 | Server   | `tools`        | Exposes callable [tools]({{< ref "/specification/server/tools" >}}) |
 | Server   | `logging`      | Emits structured [log messages]({{< ref "/specification/server/utilities/logging" >}}) |
+| Server   | `locale`       | | Provides [i18n support]({{< ref "/specification/server/i18n" >}}) |
 | Server   | `experimental` | Describes support for non-standard experimental features |
 
 Capability objects can describe sub-capabilities like:

--- a/docs/specification/client/_index.md
+++ b/docs/specification/client/_index.md
@@ -14,4 +14,5 @@ Clients can implement additional features to enrich connected MCP servers:
 {{< cards >}}
   {{< card link="roots" title="Roots" icon="folder" >}}
   {{< card link="sampling" title="Sampling" icon="annotation" >}}
+  {{< card link="i18n" title="I18n support" icon="globe-alt" >}}
 {{< /cards >}}

--- a/docs/specification/client/i18n.md
+++ b/docs/specification/client/i18n.md
@@ -1,0 +1,11 @@
+---
+title: I18n support
+type: docs
+weight: 40
+---
+
+{{< callout type="info" >}}
+**Protocol Revision**: {{< param protocolRevision >}}
+{{< /callout >}}
+
+Coming soon.

--- a/docs/specification/server/_index.md
+++ b/docs/specification/server/_index.md
@@ -29,4 +29,5 @@ Explore these key primitives in more detail below:
   {{< card link="prompts" title="Prompts" icon="chat-alt-2" >}}
   {{< card link="resources" title="Resources" icon="document" >}}
   {{< card link="tools" title="Tools" icon="adjustments" >}}
+  {{< card link="i18n" title="I18n support" icon="globe-alt" >}}
 {{< /cards >}}

--- a/docs/specification/server/i18n.md
+++ b/docs/specification/server/i18n.md
@@ -1,0 +1,11 @@
+---
+title: I18n support
+type: docs
+weight: 40
+---
+
+{{< callout type="info" >}}
+**Protocol Revision**: {{< param protocolRevision >}}
+{{< /callout >}}
+
+Coming soon.

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -153,6 +153,22 @@
                     "description": "Experimental, non-standard capabilities that the client supports.",
                     "type": "object"
                 },
+                "locale": {
+                    "description": "Present if the client has a list of preferred languages for translatable fields.",
+                    "properties": {
+                        "preferredLanguages": {
+                            "description": "An array of preferred languages for translatable fields, listed in descending order of priority.",
+                            "items": {
+                                "$ref": "#/definitions/LanguageTag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "preferredLanguages"
+                    ],
+                    "type": "object"
+                },
                 "roots": {
                     "description": "Present if the client supports listing roots.",
                     "properties": {
@@ -821,6 +837,10 @@
                 "result"
             ],
             "type": "object"
+        },
+        "LanguageTag": {
+            "description": "A string representing a BCP 47 language tag.",
+            "type": "string"
         },
         "ListPromptsRequest": {
             "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
@@ -1741,6 +1761,19 @@
                         "type": "object"
                     },
                     "description": "Experimental, non-standard capabilities that the server supports.",
+                    "type": "object"
+                },
+                "locale": {
+                    "description": "Present if the server specifies the language it uses for translatable fields.",
+                    "properties": {
+                        "language": {
+                            "$ref": "#/definitions/LanguageTag",
+                            "description": "The language used by the server for translatable fields."
+                        }
+                    },
+                    "required": [
+                        "language"
+                    ],
                     "type": "object"
                 },
                 "logging": {

--- a/schema/schema.ts
+++ b/schema/schema.ts
@@ -183,6 +183,11 @@ export interface InitializedNotification extends Notification {
 }
 
 /**
+ * A string representing a BCP 47 language tag.
+ */
+export type LanguageTag = string;
+
+/**
  * Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.
  */
 export interface ClientCapabilities {
@@ -203,6 +208,15 @@ export interface ClientCapabilities {
    * Present if the client supports sampling from an LLM.
    */
   sampling?: object;
+  /**
+   * Present if the client has a list of preferred languages for translatable fields.
+   */
+  locale?: {
+    /**
+     * An array of preferred languages for translatable fields, listed in descending order of priority.
+     */
+    preferredLanguages: LanguageTag[];
+  };
 }
 
 /**
@@ -247,6 +261,15 @@ export interface ServerCapabilities {
      * Whether this server supports notifications for changes to the tool list.
      */
     listChanged?: boolean;
+  };
+  /**
+   * Present if the server specifies the language it uses for translatable fields.
+   */
+  locale?: {
+    /**
+     * The language used by the server for translatable fields.
+     */
+    language: LanguageTag;
   };
 }
 


### PR DESCRIPTION
## Motivation and Context
Fixes #86.

Temporary PR for further discussion. Documentation very partially updated for now.

Note : "preferredLanguage", as a string, has been turned into "preferredLanguage**s**", as an array of strings, which is a more common practice.

## How Has This Been Tested?
Not so well, I fear...

## Breaking Changes
None (Only new optional fields in initialization messages).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context

