### PR TITLE
nit: Add `ListResourceTemplates` to `ClientRequest` / `ServerResult` in schema.ts

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -200,6 +200,9 @@
                     "$ref": "#/definitions/ListResourcesRequest"
                 },
                 {
+                    "$ref": "#/definitions/ListResourceTemplatesRequest"
+                },
+                {
                     "$ref": "#/definitions/ReadResourceRequest"
                 },
                 {
@@ -1834,6 +1837,9 @@
                 },
                 {
                     "$ref": "#/definitions/ListResourcesResult"
+                },
+                {
+                    "$ref": "#/definitions/ListResourceTemplatesResult"
                 },
                 {
                     "$ref": "#/definitions/ReadResourceResult"

--- a/schema/schema.ts
+++ b/schema/schema.ts
@@ -1108,6 +1108,7 @@ export type ServerResult =
   | GetPromptResult
   | ListPromptsResult
   | ListResourcesResult
+  | ListResourceTemplatesResult
   | ReadResourceResult
   | CallToolResult
   | ListToolsResult;

--- a/schema/schema.ts
+++ b/schema/schema.ts
@@ -1072,6 +1072,7 @@ export type ClientRequest =
   | GetPromptRequest
   | ListPromptsRequest
   | ListResourcesRequest
+  | ListResourceTemplatesRequest
   | ReadResourceRequest
   | SubscribeRequest
   | UnsubscribeRequest


### PR DESCRIPTION
Based on my understanding of the specs, it seems that those values were forgotten in the `ClientRequest ` / `ServerResult` type.

## Motivation and Context
This change aligns `schema.ts` with the description of the specs found in https://spec.modelcontextprotocol.io/specification/server/resources/

## How Has This Been Tested?
NA

## Breaking Changes
Possibly breaking Typescript compilation for developers referencing `ClientRequest ` / `ServerResult`. Still mostly a bug fix.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

