### PR TITLE
fix: incorrect link for "Specification (Draft)" on nav bar

### DIFF
--- a/docs/specification/draft/_index.md
+++ b/docs/specification/draft/_index.md
@@ -4,6 +4,8 @@ cascade:
   type: docs
 breadcrumbs: false
 weight: 10
+aliases:
+  - /draft
 ---
 
 {{< callout type="info" >}}

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -59,7 +59,7 @@ enableInlineShortcodes: true
 menu:
   main:
     - name: Specification (Draft)
-      pageRef: /draft
+      pageRef: /specification/draft
       weight: 1
     - name: Specification (Latest)
       pageRef: /latest

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -59,7 +59,7 @@ enableInlineShortcodes: true
 menu:
   main:
     - name: Specification (Draft)
-      pageRef: /specification/draft
+      pageRef: /draft
       weight: 1
     - name: Specification (Latest)
       pageRef: /latest


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Fix a link that redirects to 404

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

After clicking this link on the navbar, it takes us to a 404 page.

![image](https://github.com/user-attachments/assets/227dd5da-ed33-4476-9380-ceab34c40581)

![image](https://github.com/user-attachments/assets/22699df1-d775-4643-a104-1d3aa3be1609)

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Run `npm run serve:docs` and observe the link takes us to the `/specification/draft`

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
