### PR TITLE
Fix broken links in DRAFT and 2024-11-05 spec docs.

### DIFF
--- a/docs/resources/_index.md
+++ b/docs/resources/_index.md
@@ -9,8 +9,8 @@ sidebar:
 The Model Context Protocol (MCP) provides multiple resources for documentation and implementation:
 
 - **User Documentation**: Visit [modelcontextprotocol.io](https://modelcontextprotocol.io) for comprehensive user-facing documentation
-- **Python SDK**: The Python implementation is available at [github.com/modelcontextprotocol/python-sdk](https://github.com/modelcontextprotocol/python-sdk) - [Discussions](https://github.com/modelcontextprotocol/python-sdk/discussions)
+- **Python SDK**: The Python implementation is available at [github.com/modelcontextprotocol/python-sdk](https://github.com/modelcontextprotocol/python-sdk) - [Issues](https://github.com/modelcontextprotocol/python-sdk/issues)
 - **Specification**: The core specification is available at [github.com/modelcontextprotocol/specification](https://github.com/modelcontextprotocol/specification) - [Discussions](https://github.com/modelcontextprotocol/specification/discussions)
-- **TypeScript SDK**: The TypeScript implementation can be found at [github.com/modelcontextprotocol/typescript-sdk](https://github.com/modelcontextprotocol/typescript-sdk) - [Discussions](https://github.com/modelcontextprotocol/typescript-sdk/discussions)
+- **TypeScript SDK**: The TypeScript implementation can be found at [github.com/modelcontextprotocol/typescript-sdk](https://github.com/modelcontextprotocol/typescript-sdk) - [Issues](https://github.com/modelcontextprotocol/typescript-sdk/issues)
 
 For questions or discussions, please open a discussion in the appropriate GitHub repository based on your implementation or use case. You can also visit the [Model Context Protocol organization on GitHub](https://github.com/modelcontextprotocol) to see all repositories and ongoing development.

--- a/docs/specification/2024-11-05/_index.md
+++ b/docs/specification/2024-11-05/_index.md
@@ -14,7 +14,7 @@ aliases:
 
 [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is an open protocol that enables seamless integration between LLM applications and external data sources and tools. Whether you're building an AI-powered IDE, enhancing a chat interface, or creating custom AI workflows, MCP provides a standardized way to connect LLMs with the context they need.
 
-This specification defines the authoritative protocol requirements, based on the TypeScript schema in [schema.ts](https://github.com/modelcontextprotocol/specification/2024-11-05/blob/main/schema/schema.ts).
+This specification defines the authoritative protocol requirements, based on the TypeScript schema in [schema.ts](https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.ts).
 
 For implementation guides and examples, visit [modelcontextprotocol.io](https://modelcontextprotocol.io).
 

--- a/docs/specification/2024-11-05/basic/_index.md
+++ b/docs/specification/2024-11-05/basic/_index.md
@@ -46,12 +46,12 @@ See the following pages for more details on the different components:
 
 ## Auth
 
-Authentication and authorization are not currently part of the core MCP specification, but we are considering ways to introduce them in future. Join us in [GitHub Discussions](https://github.com/modelcontextprotocol/specification/2024-11-05/discussions) to help shape the future of the protocol!
+Authentication and authorization are not currently part of the core MCP specification, but we are considering ways to introduce them in future. Join us in [GitHub Discussions](https://github.com/modelcontextprotocol/specification/discussions) to help shape the future of the protocol!
 
 Clients and servers **MAY** negotiate their own custom authentication and authorization strategies.
 
 ## Schema
 
-The full specification of the protocol is defined as a [TypeScript schema](http://github.com/modelcontextprotocol/specification/2024-11-05/tree/main/schema/schema.ts). This is the source of truth for all protocol messages and structures.
+The full specification of the protocol is defined as a [TypeScript schema](http://github.com/modelcontextprotocol/specification/tree/main/schema/2024-11-05/schema.ts). This is the source of truth for all protocol messages and structures.
 
-There is also a [JSON Schema](http://github.com/modelcontextprotocol/specification/2024-11-05/tree/main/schema/schema.json), which is automatically generated from the TypeScript source of truth, for use with various automated tooling.
+There is also a [JSON Schema](http://github.com/modelcontextprotocol/specification/tree/main/schema/2024-11-05/schema.json), which is automatically generated from the TypeScript source of truth, for use with various automated tooling.

--- a/docs/specification/2024-11-05/contributing/_index.md
+++ b/docs/specification/2024-11-05/contributing/_index.md
@@ -6,8 +6,8 @@ cascade:
 breadcrumbs: false
 ---
 
-We welcome contributions from the community! Please review our [contributing guidelines](https://github.com/modelcontextprotocol/specification/2024-11-05/blob/main/CONTRIBUTING.md) for details on how to submit changes.
+We welcome contributions from the community! Please review our [contributing guidelines](https://github.com/modelcontextprotocol/specification/blob/main/CONTRIBUTING.md) for details on how to submit changes.
 
-All contributors must adhere to our [Code of Conduct](https://github.com/modelcontextprotocol/specification/2024-11-05/blob/main/CODE_OF_CONDUCT.md).
+All contributors must adhere to our [Code of Conduct](https://github.com/modelcontextprotocol/specification/blob/main/CODE_OF_CONDUCT.md).
 
-For questions and discussions, please use [GitHub Discussions](https://github.com/modelcontextprotocol/specification/2024-11-05/discussions).
+For questions and discussions, please use [GitHub Discussions](https://github.com/modelcontextprotocol/specification/discussions).

--- a/docs/specification/draft/_index.md
+++ b/docs/specification/draft/_index.md
@@ -12,7 +12,7 @@ weight: 10
 
 [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is an open protocol that enables seamless integration between LLM applications and external data sources and tools. Whether you're building an AI-powered IDE, enhancing a chat interface, or creating custom AI workflows, MCP provides a standardized way to connect LLMs with the context they need.
 
-This specification defines the authoritative protocol requirements, based on the TypeScript schema in [schema.ts](https://github.com/modelcontextprotocol/specification/draft/blob/main/schema/schema.ts).
+This specification defines the authoritative protocol requirements, based on the TypeScript schema in [schema.ts](https://github.com/modelcontextprotocol/specification/blob/main/schema/draft/schema.ts).
 
 For implementation guides and examples, visit [modelcontextprotocol.io](https://modelcontextprotocol.io).
 

--- a/docs/specification/draft/basic/_index.md
+++ b/docs/specification/draft/basic/_index.md
@@ -46,12 +46,12 @@ See the following pages for more details on the different components:
 
 ## Auth
 
-Authentication and authorization are not currently part of the core MCP specification, but we are considering ways to introduce them in future. Join us in [GitHub Discussions](https://github.com/modelcontextprotocol/specification/draft/discussions) to help shape the future of the protocol!
+Authentication and authorization are not currently part of the core MCP specification, but we are considering ways to introduce them in future. Join us in [GitHub Discussions](https://github.com/modelcontextprotocol/specification/discussions) to help shape the future of the protocol!
 
 Clients and servers **MAY** negotiate their own custom authentication and authorization strategies.
 
 ## Schema
 
-The full specification of the protocol is defined as a [TypeScript schema](http://github.com/modelcontextprotocol/specification/draft/tree/main/schema/schema.ts). This is the source of truth for all protocol messages and structures.
+The full specification of the protocol is defined as a [TypeScript schema](http://github.com/modelcontextprotocol/specification/tree/main/schema/draft/schema.ts). This is the source of truth for all protocol messages and structures.
 
-There is also a [JSON Schema](http://github.com/modelcontextprotocol/specification/draft/tree/main/schema/schema.json), which is automatically generated from the TypeScript source of truth, for use with various automated tooling.
+There is also a [JSON Schema](http://github.com/modelcontextprotocol/specification/tree/main/schema/draft/schema.json), which is automatically generated from the TypeScript source of truth, for use with various automated tooling.

--- a/docs/specification/draft/contributing/_index.md
+++ b/docs/specification/draft/contributing/_index.md
@@ -6,8 +6,8 @@ cascade:
 breadcrumbs: false
 ---
 
-We welcome contributions from the community! Please review our [contributing guidelines](https://github.com/modelcontextprotocol/specification/draft/blob/main/CONTRIBUTING.md) for details on how to submit changes.
+We welcome contributions from the community! Please review our [contributing guidelines](https://github.com/modelcontextprotocol/specification/blob/main/CONTRIBUTING.md) for details on how to submit changes.
 
-All contributors must adhere to our [Code of Conduct](https://github.com/modelcontextprotocol/specification/draft/blob/main/CODE_OF_CONDUCT.md).
+All contributors must adhere to our [Code of Conduct](https://github.com/modelcontextprotocol/specification/blob/main/CODE_OF_CONDUCT.md).
 
-For questions and discussions, please use [GitHub Discussions](https://github.com/modelcontextprotocol/specification/draft/discussions).
+For questions and discussions, please use [GitHub Discussions](https://github.com/modelcontextprotocol/specification/discussions).


### PR DESCRIPTION
Fix broken links. 2024-11-05 `schema.ts`/`schema.json` points to `main/schema/2024-11-05/schema.ts` in anticipation of PR #145 being merged.

This fixes: 
 - Code of Conduct/Contributing Links
 - SDK links now point to "Issues" rather than "Discussions"
 - schema.ts/schema/json links.

## Motivation and Context

## How Has This Been Tested?
Tested locally. Links to the 2024-11-05 versions point to `main/schema/2024-11-05/schema.ts` in anticipation of #145 being merged.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context

