### PR TITLE
RFC Stateless

### DIFF
--- a/docs/specification/2024-11-05/architecture/_index.md
+++ b/docs/specification/2024-11-05/architecture/_index.md
@@ -9,7 +9,8 @@ The Model Context Protocol (MCP) follows a client-host-server architecture where
 host can run multiple client instances. This architecture enables users to integrate AI
 capabilities across applications while maintaining clear security boundaries and
 isolating concerns. Built on JSON-RPC, MCP provides a stateful session protocol focused
-on context exchange and sampling coordination between clients and servers.
+on context exchange and sampling coordination between clients and servers. A stateless
+version of the protocol is available, which provides a limited subset of the capabiities.
 
 ## Core Components
 
@@ -61,7 +62,7 @@ The host process acts as the container and coordinator:
 
 Each client is created by the host and maintains an isolated server connection:
 
-- Establishes one stateful session per server
+- Establishes one stateful or stateless session per server
 - Handles protocol negotiation and capability exchange
 - Routes protocol messages bidirectionally
 - Manages subscriptions and notifications
@@ -174,6 +175,8 @@ sequenceDiagram
     Client->>-Server: End session
     deactivate Server
 ```
+
+In case of stateless connection, there will be no "Server Request".
 
 Each capability unlocks specific protocol features for use during the session. For
 example:

--- a/docs/specification/2024-11-05/architecture/_index.md
+++ b/docs/specification/2024-11-05/architecture/_index.md
@@ -10,7 +10,7 @@ host can run multiple client instances. This architecture enables users to integ
 capabilities across applications while maintaining clear security boundaries and
 isolating concerns. Built on JSON-RPC, MCP provides a stateful session protocol focused
 on context exchange and sampling coordination between clients and servers. A stateless
-version of the protocol is available, which provides a limited subset of the capabiities.
+version of the protocol is available, which provides a subset of the capabiities.
 
 ## Core Components
 
@@ -176,7 +176,7 @@ sequenceDiagram
     deactivate Server
 ```
 
-In case of stateless connection, there will be no "Server Request".
+In case of stateless transport, there will be no "Server Request".
 
 Each capability unlocks specific protocol features for use during the session. For
 example:

--- a/docs/specification/2024-11-05/basic/lifecycle.md
+++ b/docs/specification/2024-11-05/basic/lifecycle.md
@@ -103,7 +103,7 @@ The server **MUST** respond with its own capabilities and information:
 }
 ```
 
-When using _statful_ transports, after successful initialization, the client **MUST**
+When using _stateful_ transports, after successful initialization, the client **MUST**
 send an `initialized` notification to indicate it is ready to begin normal operations:
 
 ```json
@@ -126,7 +126,7 @@ send an `initialized` notification to indicate it is ready to begin normal opera
 In the `initialize` request, the client **MUST** send a protocol version it supports.
 This **SHOULD** be the _latest_ version supported by the client.
 
-For _statful_ transports, if the server supports the requested protocol version, it 
+For _stateful_ transports, if the server supports the requested protocol version, it 
 **MUST** respond with the same version. Otherwise, the server **MUST** respond with
 another protocol version it supports. This **SHOULD** be the _latest_ version supported
 by the server.

--- a/docs/specification/2024-11-05/basic/lifecycle.md
+++ b/docs/specification/2024-11-05/basic/lifecycle.md
@@ -192,12 +192,12 @@ exiting.
 
 #### SSE
 
-For SSE [transports]({{< ref "/specification/2024-11-05/basic/transports" >}}), shutdown
+For SSE [transport]({{< ref "/specification/2024-11-05/basic/transports" >}}), shutdown
 is indicated by closing the associated SSE connection(s).
 
 #### HTTP
 
-For HTTP [transports]({{< ref "/specification/2024-11-05/basic/transports" >}}), shutdown
+For HTTP [transport]({{< ref "/specification/2024-11-05/basic/transports" >}}), shutdown
 is not needed.
 
 ## Error Handling

--- a/docs/specification/2024-11-05/basic/lifecycle.md
+++ b/docs/specification/2024-11-05/basic/lifecycle.md
@@ -103,8 +103,8 @@ The server **MUST** respond with its own capabilities and information:
 }
 ```
 
-After successful initialization, the client **MUST** send an `initialized` notification
-to indicate it is ready to begin normal operations:
+When using _statfull_ transports, after successful initialization, the client **MUST**
+send an `initialized` notification to indicate it is ready to begin normal operations:
 
 ```json
 {
@@ -126,9 +126,13 @@ to indicate it is ready to begin normal operations:
 In the `initialize` request, the client **MUST** send a protocol version it supports.
 This **SHOULD** be the _latest_ version supported by the client.
 
-If the server supports the requested protocol version, it **MUST** respond with the same
-version. Otherwise, the server **MUST** respond with another protocol version it
-supports. This **SHOULD** be the _latest_ version supported by the server.
+For _statfull_ transports, if the server supports the requested protocol version, it 
+**MUST** respond with the same version. Otherwise, the server **MUST** respond with
+another protocol version it supports. This **SHOULD** be the _latest_ version supported
+by the server.
+
+For _stateless_ transports, the server **SHOULD** respond with the _latest_ version
+supported by the server.
 
 If the client does not support the version in the server's response, it **SHOULD**
 disconnect.
@@ -186,10 +190,15 @@ client **SHOULD** initiate shutdown by:
 The server **MAY** initiate shutdown by closing its output stream to the client and
 exiting.
 
+#### SSE
+
+For SSE [transports]({{< ref "/specification/2024-11-05/basic/transports" >}}), shutdown
+is indicated by closing the associated SSE connection(s).
+
 #### HTTP
 
 For HTTP [transports]({{< ref "/specification/2024-11-05/basic/transports" >}}), shutdown
-is indicated by closing the associated HTTP connection(s).
+is not needed.
 
 ## Error Handling
 

--- a/docs/specification/2024-11-05/basic/lifecycle.md
+++ b/docs/specification/2024-11-05/basic/lifecycle.md
@@ -103,7 +103,7 @@ The server **MUST** respond with its own capabilities and information:
 }
 ```
 
-When using _statfull_ transports, after successful initialization, the client **MUST**
+When using _statful_ transports, after successful initialization, the client **MUST**
 send an `initialized` notification to indicate it is ready to begin normal operations:
 
 ```json
@@ -126,7 +126,7 @@ send an `initialized` notification to indicate it is ready to begin normal opera
 In the `initialize` request, the client **MUST** send a protocol version it supports.
 This **SHOULD** be the _latest_ version supported by the client.
 
-For _statfull_ transports, if the server supports the requested protocol version, it 
+For _statful_ transports, if the server supports the requested protocol version, it 
 **MUST** respond with the same version. Otherwise, the server **MUST** respond with
 another protocol version it supports. This **SHOULD** be the _latest_ version supported
 by the server.

--- a/docs/specification/2024-11-05/basic/messages.md
+++ b/docs/specification/2024-11-05/basic/messages.md
@@ -13,7 +13,7 @@ three types of messages:
 
 ## Requests
 
-Requests are sent from the client to the server or vice versa.
+Requests are sent from the client to the server, or vice versa if the transport and capabilities allows.
 
 ```typescript
 {

--- a/docs/specification/2024-11-05/basic/messages.md
+++ b/docs/specification/2024-11-05/basic/messages.md
@@ -13,7 +13,8 @@ three types of messages:
 
 ## Requests
 
-Requests are sent from the client to the server, or vice versa if the transport and capabilities allows.
+Requests are sent from the client to the server, or vice versa if the transport
+qand capabilities allows (e.g. the HTTP transport does not allow server requests).
 
 ```typescript
 {
@@ -56,8 +57,9 @@ Responses are sent in reply to requests.
 
 ## Notifications
 
-Notifications are sent from the client to the server or vice versa. They do not expect a
-response.
+Notifications are sent from the client to the server or vice versa if the transport
+and capabilities allows (e.g. the HTTP transport does not allow server notifications).
+Notifications do not expect a response.
 
 ```typescript
 {

--- a/docs/specification/2024-11-05/basic/transports.md
+++ b/docs/specification/2024-11-05/basic/transports.md
@@ -11,15 +11,15 @@ MCP currently defines three standard transport mechanisms for client-server comm
 
 1. [stdio](#stdio), communication over standard in and standard out
 2. [SSE](#http-with-sse) (HTTP with Server-Sent Events)
-3. [HTTP](#http-stateless) (HTTP using POST requests)
+3. [HTTP](#http) (HTTP using POST requests)
 
 Transports **stdio** and **SSE** are _stateful_ transports, while **HTTP** MAY be _stateless_.
 Servers **MUST** support one or more of **stdio**, **SSE**, or **HTTP** transports.
 Clients **SHOULD** support stdio whenever possible.
 
 If the server support multiple transports, clients **MAY** choose different transports
-depending on their needs at different times, e.g. start with an **HTTP** transport
-for simple _statless_ tools, and switch to **SSE** for server notifications.
+depending on their needs at different times, e.g. use **HTTP** transport
+for simple _statless_ tools, and use **SSE** for server notifications.
 
 It is also possible for clients and servers to implement
 [custom transports](#custom-transports) in a pluggable fashion.

--- a/docs/specification/2024-11-05/basic/transports.md
+++ b/docs/specification/2024-11-05/basic/transports.md
@@ -7,11 +7,14 @@ weight: 40
 {{< callout type="info" >}} **Protocol Revision**: {{< param protocolRevision >}}
 {{< /callout >}}
 
-MCP currently defines two standard transport mechanisms for client-server communication:
+MCP currently defines three standard transport mechanisms for client-server communication:
 
 1. [stdio](#stdio), communication over standard in and standard out
 2. [HTTP with Server-Sent Events](#http-with-sse) (SSE)
+3. [HTTP](#http-stateless)
 
+Transports **stdio** and **SSE** are _statefull_ transports, while **HTTP** is _stateless_.
+Servers **MUST** support one or more of **stdio**, **SSE**, or **HTTP** transports.
 Clients **SHOULD** support stdio whenever possible.
 
 It is also possible for clients and servers to implement
@@ -46,7 +49,7 @@ sequenceDiagram
     deactivate Server Process
 ```
 
-## HTTP with SSE
+## SSE
 
 In the **SSE** transport, the server operates as an independent process that can handle
 multiple client connections.
@@ -76,6 +79,30 @@ sequenceDiagram
         Server->>Client: SSE message events
     end
     Client->>Server: Close SSE connection
+```
+
+## HTTP
+
+The **HTTP** transport is _stateless_. 
+
+If the server supports **HTTP** _stateless_ transport, the server **MUST** provide
+one regular HTTP POST endpoint for clients to send messages to the server.
+
+In the **HTTP** transport, the server operates as an independent process that
+can handle multiple client connections. The server **MAY** answer to each request
+independently. The server **MAY NOT** have memory of any client capabilites, client
+supported versions, or previous client interations.
+
+Server requests and server notifications **MAY NOT** be implemented in **HTTP** _stateless_ transport.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    loop Message Exchange
+        Client->>Server: HTTP POST messages
+    end
 ```
 
 ## Custom Transports

--- a/docs/specification/2024-11-05/basic/transports.md
+++ b/docs/specification/2024-11-05/basic/transports.md
@@ -13,9 +13,13 @@ MCP currently defines three standard transport mechanisms for client-server comm
 2. [SSE](#http-with-sse) (HTTP with Server-Sent Events)
 3. [HTTP](#http-stateless) (HTTP using POST requests)
 
-Transports **stdio** and **SSE** are _stateful_ transports, while **HTTP** is _stateless_.
+Transports **stdio** and **SSE** are _stateful_ transports, while **HTTP** MAY be _stateless_.
 Servers **MUST** support one or more of **stdio**, **SSE**, or **HTTP** transports.
 Clients **SHOULD** support stdio whenever possible.
+
+If the server support multiple transports, clients **MAY** choose different transports
+depending on their needs at different times, e.g. start with an **HTTP** transport
+for simple _statless_ tools, and switch to **SSE** for server notifications.
 
 It is also possible for clients and servers to implement
 [custom transports](#custom-transports) in a pluggable fashion.
@@ -81,11 +85,14 @@ sequenceDiagram
     Client->>Server: Close SSE connection
 ```
 
+Servers maintain **SSE** connections on a *"best effort"* approach. This means
+that servers **MAY** disconnect and loose client state. 
+
 ## HTTP
 
-The **HTTP** transport is _stateless_. 
+The **HTTP** transport MAY be _stateless_. 
 
-If the server supports **HTTP** _stateless_ transport, the server **MUST** provide
+If the server supports **HTTP** transport, the server **MUST** provide
 one regular HTTP POST endpoint for clients to send messages to the server.
 
 In the **HTTP** transport, the server operates as an independent process that
@@ -93,7 +100,10 @@ can handle multiple client connections. The server **MAY** answer to each reques
 independently. The server **MAY NOT** have memory of any client capabilites, client
 supported versions, or previous client interations.
 
-Server requests and server notifications **MAY NOT** be implemented in **HTTP** _stateless_ transport.
+Server requests and server notifications **MAY NOT** be implemented in **HTTP**
+transport. If the server supports multiple transports, clients **MAY** use
+other transsports as needed (e.g. **SSE**) to access features not implemented
+on **HTTP** transport.
 
 ```mermaid
 sequenceDiagram

--- a/docs/specification/2024-11-05/basic/transports.md
+++ b/docs/specification/2024-11-05/basic/transports.md
@@ -13,7 +13,7 @@ MCP currently defines three standard transport mechanisms for client-server comm
 2. [SSE](#http-with-sse) (HTTP with Server-Sent Events)
 3. [HTTP](#http-stateless) (HTTP using POST requests)
 
-Transports **stdio** and **SSE** are _statefull_ transports, while **HTTP** is _stateless_.
+Transports **stdio** and **SSE** are _stateful_ transports, while **HTTP** is _stateless_.
 Servers **MUST** support one or more of **stdio**, **SSE**, or **HTTP** transports.
 Clients **SHOULD** support stdio whenever possible.
 

--- a/docs/specification/2024-11-05/basic/transports.md
+++ b/docs/specification/2024-11-05/basic/transports.md
@@ -10,8 +10,8 @@ weight: 40
 MCP currently defines three standard transport mechanisms for client-server communication:
 
 1. [stdio](#stdio), communication over standard in and standard out
-2. [HTTP with Server-Sent Events](#http-with-sse) (SSE)
-3. [HTTP](#http-stateless)
+2. [SSE](#http-with-sse) (HTTP with Server-Sent Events)
+3. [HTTP](#http-stateless) (HTTP using POST requests)
 
 Transports **stdio** and **SSE** are _statefull_ transports, while **HTTP** is _stateless_.
 Servers **MUST** support one or more of **stdio**, **SSE**, or **HTTP** transports.

--- a/docs/specification/2024-11-05/server/resources.md
+++ b/docs/specification/2024-11-05/server/resources.md
@@ -53,7 +53,7 @@ The capability supports two optional features:
   resources changes.
 
 Both `subscribe` and `listChanged` are optional&mdash;servers can support neither,
-either, or both:
+either, or both (_stateless_ servers **SHALL NOT** implement either of them):
 
 ```json
 {
@@ -209,8 +209,8 @@ capability **SHOULD** send a notification:
 
 ### Subscriptions
 
-The protocol supports optional subscriptions to resource changes. Clients can subscribe
-to specific resources and receive notifications when they change:
+When _statfull_ transports are used, the protocol supports optional subscriptions to resource
+changes. Clients can subscribe to specific resources and receive notifications when they change:
 
 **Subscribe Request:**
 
@@ -269,7 +269,7 @@ sequenceDiagram
 A resource definition includes:
 
 - `uri`: Unique identifier for the resource
-- `name`: Human-readable name
+- `name`: Optional human-readable name
 - `description`: Optional description
 - `mimeType`: Optional MIME type
 
@@ -282,6 +282,7 @@ Resources can contain either text or binary data:
 ```json
 {
   "uri": "file:///example.txt",
+  "name": "An example text file",
   "mimeType": "text/plain",
   "text": "Resource content"
 }
@@ -292,6 +293,7 @@ Resources can contain either text or binary data:
 ```json
 {
   "uri": "file:///example.png",
+  "name": "An example image",
   "mimeType": "image/png",
   "blob": "base64-encoded-data"
 }

--- a/docs/specification/2024-11-05/server/resources.md
+++ b/docs/specification/2024-11-05/server/resources.md
@@ -209,7 +209,7 @@ capability **SHOULD** send a notification:
 
 ### Subscriptions
 
-When _statfull_ transports are used, the protocol supports optional subscriptions to resource
+When _statful_ transports are used, the protocol supports optional subscriptions to resource
 changes. Clients can subscribe to specific resources and receive notifications when they change:
 
 **Subscribe Request:**

--- a/docs/specification/2024-11-05/server/resources.md
+++ b/docs/specification/2024-11-05/server/resources.md
@@ -209,7 +209,7 @@ capability **SHOULD** send a notification:
 
 ### Subscriptions
 
-When _statful_ transports are used, the protocol supports optional subscriptions to resource
+When _stateful_ transports are used, the protocol supports optional subscriptions to resource
 changes. Clients can subscribe to specific resources and receive notifications when they change:
 
 **Subscribe Request:**


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

[Related discussion](https://github.com/modelcontextprotocol/specification/discussions/102)

The scope of these RFC is to a _stateless_ transport layer (HTTP), as an alternative to SSE.
Implementing _stateless_ servers is simple, and easier to scale than SSE.
Servers may choose to implemet one (or more) of the transports (stdio, SSE, and HTTP).

## Motivation and Context

Currently the protocol offers two main transports: either `stdio` transport (i.e. local running "servers"), or remote SSE (for remote servers).

As the MCP protocol is inspired by [Language Server Protocol](https://microsoft.github.io/language-server-protocol/), the client is currently assumed to have dedicated connection/s to the server/s during a long running session. This means that MCP's SSE transport is supposed to have very long lived connections, which can be challenging to scale.

**Problem**

MCP is currently a stateful protocol, with a long-lived connection between client and server. The protocol is definitely not designed around repeatedly opening a connection, issuing one semantic request, then closing.

This is fairly limiting for serverless deployments, which frequently autoscale up and down, and generally aren't designed around long-lived requests (for example, typically there's a max request lifetime measured in minutes).

Deploying to a Platform-as-a-Service is really nice and convenient as a developer, so not being very compatible with this model creates an impediment to broader MCP adoption.

**Proposed solution**

On top of the statefull protocol, also offer _stateless_ variant of the protocol. This is done by using simple HTTP / POST with the same JSON-RBC structures already defined.

**Approach**

The changes to the specification introduced in this RFC are minimal, so we can leverage all the current specification.

We recognize that the _stateless_ server would not be able to implement the same features as a statful server. Specifically, *server notifications* and *sampling* are not possible in this simple statless server proposal. Nevertheless a client that need these features can use SSE (if made available by the server).

**Use case example**

A typical use case for the _stateless_ MCP protocol is to offer *tools*, *prompts*, and *resources* that can be easily scaled and deployed in scaling systems, such as Kubernetes clusters.

**NOT Covered**

This RFC is intentionally NOT covering other items [discussed](https://github.com/modelcontextprotocol/specification/discussions/102), specifically it does not intend to cover other ways to mitigate the "long connections" issues, such as:
- Session tokens to keep state
- Alternatives to notifications in a stateless server
- Negotiation capabilities for websockets and polling
- Authentication, Authorizations and Accounting (AAA)


## How Has This Been Tested?
This change on the specification does not alter the main protocol, only adds another transport.

## Breaking Changes
None

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This is based on an excelent [discussion](https://github.com/modelcontextprotocol/specification/discussions/102 and input from the forum. 
The idea is to create a minimal change that enables easier scaling, thus speeds up MCP adoption.
