### PR TITLE
transport: force utf-8 for transports

### DIFF
--- a/docs/specification/draft/basic/transports.md
+++ b/docs/specification/draft/basic/transports.md
@@ -6,7 +6,10 @@ weight: 10
 
 {{< callout type="info" >}} **Protocol Revision**: draft {{< /callout >}}
 
-MCP currently defines two standard transport mechanisms for client-server communication:
+MCP uses JSON-RPC to encode messages. JSON-RPC messages **MUST** be UTF-8 encoded.
+
+The protocol currently defines two standard transport mechanisms for client-server
+communication:
 
 1. [stdio](#stdio), communication over standard in and standard out
 2. [HTTP with Server-Sent Events](#http-with-sse) (SSE)


### PR DESCRIPTION
We have silently assumed that JSON-RPC will be using UTF-8 encoding.
This is usually true, but technically the JSON specification allows
for any other encoding and only asks for UTF-8, UTF-16 or UTF-32.

For MCP we want to reduce complexity in encoding negotiation and
will only allow utf-8.
