### PR TITLE
Add reference to Authorization spec in Base Protocol page

### DIFF
--- a/docs/specification/draft/basic/_index.md
+++ b/docs/specification/draft/basic/_index.md
@@ -53,13 +53,18 @@ See the following pages for more details on the different components:
 
 ## Auth
 
-Authentication and authorization are not currently part of the core MCP specification,
-but we are considering ways to introduce them in future. Join us in
+MCP provides an [Authorization]({{< ref "/specification/draft/basic/authorization" >}})
+framework for HTTP+SSE transport. Implementations using HTTP+SSE transport **SHOULD**
+conform to this specification, whereas implementations using STDIO transport **SHOULD
+NOT** follow this specification, and instead retrieve credentials from the environment.
+
+Additionally, clients and servers **MAY** negotiate their own custom authentication and
+authorization strategies.
+
+For further discussions and contributions to the evolution of MCP’s auth mechanisms, join
+us in
 [GitHub Discussions](https://github.com/modelcontextprotocol/specification/discussions)
 to help shape the future of the protocol!
-
-Clients and servers **MAY** negotiate their own custom authentication and authorization
-strategies.
 
 ## Schema
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Adjusted the Auth section in the draft Specification's Base Protocol page to reflect the fact that there is now some semblance of Auth defined.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The previous Auth section basically mentioned that Auth was a work in progress. This updates the wording to reference the fact that an Authorization framework has been defined.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
The Specification docs were run locally and links tested. Prettier formatting was applied

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
