### PR TITLE
Explicitly define the Authorization Base URL

### DIFF
--- a/docs/specification/draft/basic/authorization.md
+++ b/docs/specification/draft/basic/authorization.md
@@ -121,7 +121,8 @@ For example: `MCP-Protocol-Version: 2024-11-05`
 #### 2.3.2 Authorization Base URL
 
 The authorization base URL **MUST** be determined from the [SSE
-endpoint]({{< ref "specification/draft/basic/transports#http-with-sse" >}}) URL by discarding any existing `path` component. For example:
+endpoint]({{< ref "specification/draft/basic/transports#http-with-sse" >}}) URL by
+discarding any existing `path` component. For example:
 
 If the SSE endpoint is `https://api.example.com/v1/sse`, then:
 

--- a/docs/specification/draft/basic/authorization.md
+++ b/docs/specification/draft/basic/authorization.md
@@ -121,8 +121,7 @@ For example: `MCP-Protocol-Version: 2024-11-05`
 #### 2.3.2 Authorization Base URL
 
 The authorization base URL **MUST** be determined from the [SSE
-endpoint]({{< ref "specification/draft/basic/transports#http-with-sse" >}}) URL by
-preserving only the `scheme`, `hostname`, and `port` (if non-standard). For example:
+endpoint]({{< ref "specification/draft/basic/transports#http-with-sse" >}}) URL by discarding any existing `path` component. For example:
 
 If the SSE endpoint is `https://api.example.com/v1/sse`, then:
 

--- a/docs/specification/draft/basic/authorization.md
+++ b/docs/specification/draft/basic/authorization.md
@@ -118,16 +118,41 @@ version.
 
 For example: `MCP-Protocol-Version: 2024-11-05`
 
-#### 2.3.1 Fallbacks for Servers without Metadata Discovery
+#### 2.3.2 Authorization Base URL
+
+The authorization base URL **MUST** be determined from the [SSE
+endpoint]({{< ref "specification/draft/basic/transports#http-with-sse" >}}) URL by
+preserving only the `scheme`, `hostname`, and `port` (if non-standard). For example:
+
+If the SSE endpoint is `https://api.example.com/v1/sse`, then:
+
+- The authorization base URL is `https://api.example.com`
+- The metadata endpoint **MUST** be at
+  `https://api.example.com/.well-known/oauth-authorization-server`
+
+This ensures authorization endpoints are consistently located at the root level of the
+domain serving the SSE endpoint, regardless of any path components in the SSE endpoint
+URL.
+
+#### 2.3.3 Fallbacks for Servers without Metadata Discovery
 
 For servers that do not implement OAuth 2.0 Authorization Server Metadata, clients
-**MUST** use the following default endpoint paths relative to the server's base URL:
+**MUST** use the following default endpoint paths relative to the authorization base URL
+(as defined in [Section
+2.3.2]({{< ref "specification/draft/basic/authorization#232-authorization-base-url" >}})):
 
 | Endpoint               | Default Path | Description                          |
 | ---------------------- | ------------ | ------------------------------------ |
 | Authorization Endpoint | /authorize   | Used for authorization requests      |
 | Token Endpoint         | /token       | Used for token exchange & refresh    |
 | Registration Endpoint  | /register    | Used for dynamic client registration |
+
+For example, with an SSE endpoint of `https://api.example.com/v1/sse`, the default
+endpoints would be:
+
+- `https://api.example.com/authorize`
+- `https://api.example.com/token`
+- `https://api.example.com/register`
 
 Clients **MUST** first attempt to discover endpoints via the metadata document before
 falling back to default paths. When using default paths, all other protocol requirements


### PR DESCRIPTION
This PR defines how to construct the OAuth server's base URL from the SSE endpoint URL. This base URL is used to locate both the Metadata Discovery endpoint and Fallback authorization endpoints.

## Motivation and Context
The [draft Authorization Specification](https://spec.modelcontextprotocol.io/specification/draft/basic/authorization/) includes mention of a `baseUrl` that the Metadata and Fallback endpoints are constructed relative to. However, it doesn't specify how to actually construct this `baseUrl`.

In the original [Authorization Support PR](https://github.com/modelcontextprotocol/specification/pull/133) there was some discussion about having a stricter definition for the server's `baseUrl` although at the time it was unspecified.

Given the implementations of OAuth Metadata Discovery in the [Inspector](https://github.com/modelcontextprotocol/inspector/pull/143) and [Typescript SDK](https://github.com/modelcontextprotocol/typescript-sdk/pull/144) it seems the `baseUrl` is derived from simply taking the scheme, protocol, and port from the SSE Url used during connection.

It's necessary for MCP Clients to understand how to construct this URL in order to properly authenticate, so this PR formalizes the definition relative to the SSE Url.

Another tiny problem was that there were multiple 2.3.1 sections in the Authorization page.

## How Has This Been Tested?
Verified by running the docs locally that all links and references are correct and that everything looks fine visually.

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
The downside of this approach is the inflexibility it provides when wanting to host multiple MCP Servers on one domain. Down the line we'll likely want to allow the MCP Client to explicitly configure the Base/Issuer URL which would take priority. Also it's weird from the perspective of URL structure inconsistency, version management, etc.

Other options include:
- Allow the server to specify its base URL in the SSE response headers or 401 Unauthorized response (already discussed in the [Authorization Support PR](https://github.com/modelcontextprotocol/specification/pull/133) as not ideal for client implementation)
- Separate discovery endpoint (eg. /.well-known/mcp) - was also [discussed](https://github.com/modelcontextprotocol/specification/pull/133) already
- Preserver path and simply remove the outermost layer (eg. example.com/api/sse becomes example.com/api) - Think this is also a reasonable approach but maybe a little more complicated to handle as a client