### PR TITLE
fix: documentation bug in SetLevelRequest

### DIFF
--- a/schema/2024-11-05/schema.json
+++ b/schema/2024-11-05/schema.json
@@ -1876,7 +1876,7 @@
                     "properties": {
                         "level": {
                             "$ref": "#/definitions/LoggingLevel",
-                            "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/logging/message."
+                            "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message."
                         }
                     },
                     "required": [

--- a/schema/2024-11-05/schema.ts
+++ b/schema/2024-11-05/schema.ts
@@ -714,7 +714,7 @@ export interface SetLevelRequest extends Request {
   method: "logging/setLevel";
   params: {
     /**
-     * The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/logging/message.
+     * The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message.
      */
     level: LoggingLevel;
   };

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -1920,7 +1920,7 @@
                     "properties": {
                         "level": {
                             "$ref": "#/definitions/LoggingLevel",
-                            "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/logging/message."
+                            "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message."
                         }
                     },
                     "required": [

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -707,7 +707,7 @@ export interface SetLevelRequest extends Request {
   method: "logging/setLevel";
   params: {
     /**
-     * The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/logging/message.
+     * The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message.
      */
     level: LoggingLevel;
   };


### PR DESCRIPTION
The description SetLevelRequest mention that logging notification
to be `notifications/logging/message` while in fact it is
`notifications/message`.

Github-Issue: #167
