### PR TITLE
Completions capability flag

### DIFF
--- a/docs/specification/draft/server/utilities/completion.md
+++ b/docs/specification/draft/server/utilities/completion.md
@@ -21,6 +21,18 @@ However, implementations are free to expose completion through any interface pat
 suits their needs&mdash;the protocol itself does not mandate any specific user
 interaction model.
 
+## Capabilities
+
+Servers that support completions **MUST** declare the `completions` capability:
+
+```json
+{
+  "capabilities": {
+    "completions": {}
+  }
+}
+```
+
 ## Protocol Messages
 
 ### Requesting Completions
@@ -112,6 +124,15 @@ sequenceDiagram
   - `values`: Array of suggestions (max 100)
   - `total`: Optional total matches
   - `hasMore`: Additional results flag
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Method not found: `-32601` (Capability not supported)
+- Invalid prompt name: `-32602` (Invalid params)
+- Missing required arguments: `-32602` (Invalid params)
+- Internal errors: `-32603` (Internal error)
 
 ## Implementation Considerations
 

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -1788,6 +1788,12 @@
         "ServerCapabilities": {
             "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
             "properties": {
+                "completions": {
+                    "additionalProperties": true,
+                    "description": "Present if the server supports argument autocompletion suggestions.",
+                    "properties": {},
+                    "type": "object"
+                },
                 "experimental": {
                     "additionalProperties": {
                         "additionalProperties": true,

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -218,6 +218,10 @@ export interface ServerCapabilities {
    */
   logging?: object;
   /**
+   * Present if the server supports argument autocompletion suggestions.
+   */
+  completions?: object;
+  /**
    * Present if the server offers any prompt templates.
    */
   prompts?: {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The completions capability is the only one without a ServerCapabilities flag, which doesn't make sense as not all servers will support it, and clients should be able to query that up front to avoid calling the method. See #157.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Not yet no. It's relatively trivial and aligns with the capability flags. I'll implement this in mcpdotnet if/when the PR is merged.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
In principle yes, as servers should now expose the `completions` capability explicitly. After this change, clients that query servers may assume that a server not exposing the capability does not support it. In practice, this capability is so tightly coupled to server documentation (as there is no mechanism for servers to communicate what completion parameters they support) that clients will likely be hardcoded to use completions with specific servers, making this a breaking change in theory only.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
