### PR TITLE
docs: Add explicit MUST NOT for notification response

### DIFF
--- a/docs/specification/draft/basic/messages.md
+++ b/docs/specification/draft/basic/messages.md
@@ -55,8 +55,8 @@ Responses are sent in reply to requests.
 
 ## Notifications
 
-Notifications are sent from the client to the server or vice versa. They do not expect a
-response.
+Notifications are sent from the client to the server or vice versa. The receiver **MUST NOT**
+send a response.
 
 ```typescript
 {


### PR DESCRIPTION
Rephrasing the sentence about Notification response. According to JSON RPC spec the server **MUST NOT** send a response.

## Motivation and Context
I'm currently working on an SDK and was a bit confused about the wording here, but the original JSON RPC spec helped: https://www.jsonrpc.org/specification#notification

## How Has This Been Tested?
not applicable?

## Breaking Changes
This is only about being more explicit in the docs - I don't think this is a breaking change.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
