### PR TITLE
Added optional message field to progress notifications

### DIFF
--- a/docs/specification/draft/basic/utilities/progress.md
+++ b/docs/specification/draft/basic/utilities/progress.md
@@ -36,6 +36,7 @@ The receiver **MAY** then send progress notifications containing:
 - The original progress token
 - The current progress value so far
 - An optional "total" value
+- An optional "message" value
 
 ```json
 {
@@ -44,7 +45,8 @@ The receiver **MAY** then send progress notifications containing:
   "params": {
     "progressToken": "abc123",
     "progress": 50,
-    "total": 100
+    "total": 100,
+    "message": "Reticulating splines..."
   }
 }
 ```
@@ -52,6 +54,7 @@ The receiver **MAY** then send progress notifications containing:
 - The `progress` value **MUST** increase with each notification, even if the total is
   unknown.
 - The `progress` and the `total` values **MAY** be floating point.
+- The `message` field **SHOULD** provide relevant human readable progress information.
 
 ## Behavior Requirements
 

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -1284,6 +1284,10 @@
                 },
                 "params": {
                     "properties": {
+                        "message": {
+                            "description": "An optional message describing the current progress.",
+                            "type": "string"
+                        },
                         "progress": {
                             "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
                             "type": "number"

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -289,6 +289,10 @@ export interface ProgressNotification extends Notification {
      * @TJS-type number
      */
     total?: number;
+    /**
+     * An optional message describing the current progress.
+     */
+    message?: string;
   };
 }
 


### PR DESCRIPTION
Add optional message field to ProgressNotification

## Motivation and Context
This change enhances the progress notification system by adding an optional human-readable message field. This allows implementers to provide more descriptive information about the current progress state, improving the user experience by communicating what operation is in progress.

## How Has This Been Tested?
The schema changes have been validated with the repository's validation tools. This is a non-breaking addition to the specification.

## Breaking Changes
None. This is a backward-compatible addition of an optional field.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
This enhancement allows for more informative progress tracking, similar to how many modern APIs implement progress updates with descriptive messages.
