### PR TITLE
replace Annotated superclass with annotations property

### DIFF
--- a/docs/specification/draft/basic/messages.md
+++ b/docs/specification/draft/basic/messages.md
@@ -55,8 +55,8 @@ Responses are sent in reply to requests.
 
 ## Notifications
 
-Notifications are sent from the client to the server or vice versa. The receiver **MUST NOT**
-send a response.
+Notifications are sent from the client to the server or vice versa. The receiver **MUST
+NOT** send a response.
 
 ```typescript
 {

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -1,26 +1,21 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
-        "Annotated": {
-            "description": "Base for objects that include optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
+        "Annotations": {
+            "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
             "properties": {
-                "annotations": {
-                    "properties": {
-                        "audience": {
-                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
-                            "items": {
-                                "$ref": "#/definitions/Role"
-                            },
-                            "type": "array"
-                        },
-                        "priority": {
-                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                            "maximum": 1,
-                            "minimum": 0,
-                            "type": "number"
-                        }
+                "audience": {
+                    "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+                    "items": {
+                        "$ref": "#/definitions/Role"
                     },
-                    "type": "object"
+                    "type": "array"
+                },
+                "priority": {
+                    "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -29,22 +24,8 @@
             "description": "Audio provided to or from an LLM.",
             "properties": {
                 "annotations": {
-                    "properties": {
-                        "audience": {
-                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
-                            "items": {
-                                "$ref": "#/definitions/Role"
-                            },
-                            "type": "array"
-                        },
-                        "priority": {
-                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                            "maximum": 1,
-                            "minimum": 0,
-                            "type": "number"
-                        }
-                    },
-                    "type": "object"
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
                 },
                 "data": {
                     "description": "The base64-encoded audio data.",
@@ -487,22 +468,8 @@
             "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
             "properties": {
                 "annotations": {
-                    "properties": {
-                        "audience": {
-                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
-                            "items": {
-                                "$ref": "#/definitions/Role"
-                            },
-                            "type": "array"
-                        },
-                        "priority": {
-                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                            "maximum": 1,
-                            "minimum": 0,
-                            "type": "number"
-                        }
-                    },
-                    "type": "object"
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
                 },
                 "resource": {
                     "anyOf": [
@@ -589,22 +556,8 @@
             "description": "An image provided to or from an LLM.",
             "properties": {
                 "annotations": {
-                    "properties": {
-                        "audience": {
-                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
-                            "items": {
-                                "$ref": "#/definitions/Role"
-                            },
-                            "type": "array"
-                        },
-                        "priority": {
-                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                            "maximum": 1,
-                            "minimum": 0,
-                            "type": "number"
-                        }
-                    },
-                    "type": "object"
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
                 },
                 "data": {
                     "description": "The base64-encoded image data.",
@@ -1528,22 +1481,8 @@
             "description": "A known resource that the server is capable of reading.",
             "properties": {
                 "annotations": {
-                    "properties": {
-                        "audience": {
-                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
-                            "items": {
-                                "$ref": "#/definitions/Role"
-                            },
-                            "type": "array"
-                        },
-                        "priority": {
-                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                            "maximum": 1,
-                            "minimum": 0,
-                            "type": "number"
-                        }
-                    },
-                    "type": "object"
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
                 },
                 "description": {
                     "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
@@ -1634,22 +1573,8 @@
             "description": "A template description for resources available on the server.",
             "properties": {
                 "annotations": {
-                    "properties": {
-                        "audience": {
-                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
-                            "items": {
-                                "$ref": "#/definitions/Role"
-                            },
-                            "type": "array"
-                        },
-                        "priority": {
-                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                            "maximum": 1,
-                            "minimum": 0,
-                            "type": "number"
-                        }
-                    },
-                    "type": "object"
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
                 },
                 "description": {
                     "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
@@ -1970,22 +1895,8 @@
             "description": "Text provided to or from an LLM.",
             "properties": {
                 "annotations": {
-                    "properties": {
-                        "audience": {
-                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
-                            "items": {
-                                "$ref": "#/definitions/Role"
-                            },
-                            "type": "array"
-                        },
-                        "priority": {
-                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                            "maximum": 1,
-                            "minimum": 0,
-                            "type": "number"
-                        }
-                    },
-                    "type": "object"
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
                 },
                 "text": {
                     "description": "The text content of the message.",

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -421,7 +421,7 @@ export interface ResourceUpdatedNotification extends Notification {
 /**
  * A known resource that the server is capable of reading.
  */
-export interface Resource extends Annotated {
+export interface Resource {
   /**
    * The URI of this resource.
    *
@@ -447,12 +447,17 @@ export interface Resource extends Annotated {
    * The MIME type of this resource, if known.
    */
   mimeType?: string;
+
+  /**
+   * Optional annotations for the client.
+   */
+  annotations?: Annotations;
 }
 
 /**
  * A template description for resources available on the server.
  */
-export interface ResourceTemplate extends Annotated {
+export interface ResourceTemplate {
   /**
    * A URI template (according to RFC 6570) that can be used to construct resource URIs.
    *
@@ -478,6 +483,11 @@ export interface ResourceTemplate extends Annotated {
    * The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.
    */
   mimeType?: string;
+
+  /**
+   * Optional annotations for the client.
+   */
+  annotations?: Annotations;
 }
 
 /**
@@ -613,9 +623,14 @@ export interface PromptMessage {
  * It is up to the client how best to render embedded resources for the benefit
  * of the LLM and/or the user.
  */
-export interface EmbeddedResource extends Annotated {
+export interface EmbeddedResource {
   type: "resource";
   resource: TextResourceContents | BlobResourceContents;
+
+  /**
+   * Optional annotations for the client.
+   */
+  annotations?: Annotations;
 }
 
 /**
@@ -813,76 +828,94 @@ export interface SamplingMessage {
 }
 
 /**
- * Base for objects that include optional annotations for the client. The client can use annotations to inform how objects are used or displayed
+ * Optional annotations for the client. The client can use annotations to inform how objects are used or displayed
  */
-export interface Annotated {
-  annotations?: {
-    /**
-     * Describes who the intended customer of this object or data is.
-     * 
-     * It can include multiple entries to indicate content useful for multiple audiences (e.g., `["user", "assistant"]`).
-     */
-    audience?: Role[];
+export interface Annotations {
+  /**
+   * Describes who the intended customer of this object or data is.
+   * 
+   * It can include multiple entries to indicate content useful for multiple audiences (e.g., `["user", "assistant"]`).
+   */
+  audience?: Role[];
 
-    /**
-     * Describes how important this data is for operating the server.
-     * 
-     * A value of 1 means "most important," and indicates that the data is
-     * effectively required, while 0 means "least important," and indicates that
-     * the data is entirely optional.
-     *
-     * @TJS-type number
-     * @minimum 0
-     * @maximum 1
-     */
-    priority?: number;
-  }
+  /**
+   * Describes how important this data is for operating the server.
+   * 
+   * A value of 1 means "most important," and indicates that the data is
+   * effectively required, while 0 means "least important," and indicates that
+   * the data is entirely optional.
+   *
+   * @TJS-type number
+   * @minimum 0
+   * @maximum 1
+   */
+  priority?: number;
 }
 
 /**
  * Text provided to or from an LLM.
  */
-export interface TextContent extends Annotated {
+export interface TextContent {
   type: "text";
+
   /**
    * The text content of the message.
    */
   text: string;
+
+  /**
+   * Optional annotations for the client.
+   */
+  annotations?: Annotations;
 }
 
 /**
  * An image provided to or from an LLM.
  */
-export interface ImageContent extends Annotated {
+export interface ImageContent {
   type: "image";
+
   /**
    * The base64-encoded image data.
    *
    * @format byte
    */
   data: string;
+
   /**
    * The MIME type of the image. Different providers may support different image types.
    */
   mimeType: string;
+
+  /**
+   * Optional annotations for the client.
+   */
+  annotations?: Annotations;
 }
 
 
 /**
  * Audio provided to or from an LLM.
  */
-export interface AudioContent extends Annotated {
+export interface AudioContent {
   type: "audio";
+
   /**
    * The base64-encoded audio data.
    *
    * @format byte
    */
   data: string;
+
   /**
    * The MIME type of the audio. Different providers may support different audio types.
    */
   mimeType: string;
+
+  /**
+   * Optional annotations for the client.
+   */
+  annotations?: Annotations;
 }
 
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Removes `Annotated` interface, and instead adds the `annotations` property directly to the interfaces that used to inherit from it. 

Previously:
```
export interface Annotated {
  annotations?: {
    // annotation properties
  }
}

export interface Foo extends Annotated {
  ...
}
```
Now:
```
export interface Annotations {
  // annotation properties
}

export interface Foo {
  annotations?: Annotations;
  ...
}
```

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Simplifies the schema, reduces friction for hosting different combinations of annotation properties on different protocol objects.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

* Wire format is unchanged.
* Typed interface hierarchy is changed, SDKs should update/provide backwards compatibility as needed.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
