### PR TITLE
Reintroduction of "size" field for Resource

### DIFF
--- a/schema/2025-03-26/schema.json
+++ b/schema/2025-03-26/schema.json
@@ -1553,6 +1553,10 @@
                     "description": "A human-readable name for this resource.\n\nThis can be used by clients to populate UI elements.",
                     "type": "string"
                 },
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+                    "type": "integer"
+                },
                 "uri": {
                     "description": "The URI of this resource.",
                     "format": "uri",

--- a/schema/2025-03-26/schema.ts
+++ b/schema/2025-03-26/schema.ts
@@ -473,6 +473,13 @@ export interface Resource {
    * Optional annotations for the client.
    */
   annotations?: Annotations;
+
+   /**
+   * The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.
+   *
+   * This can be used by Hosts to display file sizes and estimate context window usage.
+   */
+    size?: number;
 }
 
 /**


### PR DESCRIPTION
Adding `size` field to align 2024-11-05 and 2025-03-26 specifications (#132).  

## Motivation and Context
As per PR #132 

## Breaking Changes
Without, variance from 2024-11-05 may cause issues.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed
