### PR TITLE
Change pagination size requirements to conform to RFC2119 language

### DIFF
--- a/docs/specification/2024-11-05/server/utilities/pagination.md
+++ b/docs/specification/2024-11-05/server/utilities/pagination.md
@@ -17,7 +17,7 @@ data sets.
 Pagination in MCP uses an opaque cursor-based approach, instead of numbered pages.
 
 - The **cursor** is an opaque string token, representing a position in the result set
-- **Page size** is determined by the server, and **MUST NOT** be fixed
+- **Page size** is determined by the server, and clients **MUST NOT** assume a fixed page size
 
 ## Response Format
 

--- a/docs/specification/2024-11-05/server/utilities/pagination.md
+++ b/docs/specification/2024-11-05/server/utilities/pagination.md
@@ -17,7 +17,7 @@ data sets.
 Pagination in MCP uses an opaque cursor-based approach, instead of numbered pages.
 
 - The **cursor** is an opaque string token, representing a position in the result set
-- **Page size** is determined by the server, and **MAY NOT** be fixed
+- **Page size** is determined by the server, and **MUST NOT** be fixed
 
 ## Response Format
 

--- a/docs/specification/2024-11-05/server/utilities/pagination.md
+++ b/docs/specification/2024-11-05/server/utilities/pagination.md
@@ -17,7 +17,8 @@ data sets.
 Pagination in MCP uses an opaque cursor-based approach, instead of numbered pages.
 
 - The **cursor** is an opaque string token, representing a position in the result set
-- **Page size** is determined by the server, and clients **MUST NOT** assume a fixed page size
+- **Page size** is determined by the server, and clients **MUST NOT** assume a fixed page
+  size
 
 ## Response Format
 

--- a/docs/specification/2025-03-26/server/utilities/pagination.md
+++ b/docs/specification/2025-03-26/server/utilities/pagination.md
@@ -18,6 +18,7 @@ Pagination in MCP uses an opaque cursor-based approach, instead of numbered page
 
 - The **cursor** is an opaque string token, representing a position in the result set
 - **Page size** is determined by the server, and clients **MUST NOT** assume a fixed page size
+
 ## Response Format
 
 Pagination starts when the server sends a **response** that includes:

--- a/docs/specification/2025-03-26/server/utilities/pagination.md
+++ b/docs/specification/2025-03-26/server/utilities/pagination.md
@@ -17,7 +17,7 @@ data sets.
 Pagination in MCP uses an opaque cursor-based approach, instead of numbered pages.
 
 - The **cursor** is an opaque string token, representing a position in the result set
-- **Page size** is determined by the server, and **MAY NOT** be fixed
+- **Page size** is determined by the server, and **MUST NOT** be fixed
 
 ## Response Format
 

--- a/docs/specification/2025-03-26/server/utilities/pagination.md
+++ b/docs/specification/2025-03-26/server/utilities/pagination.md
@@ -17,8 +17,7 @@ data sets.
 Pagination in MCP uses an opaque cursor-based approach, instead of numbered pages.
 
 - The **cursor** is an opaque string token, representing a position in the result set
-- **Page size** is determined by the server, and **MUST NOT** be fixed
-
+- **Page size** is determined by the server, and clients **MUST NOT** assume a fixed page size
 ## Response Format
 
 Pagination starts when the server sends a **response** that includes:

--- a/docs/specification/2025-03-26/server/utilities/pagination.md
+++ b/docs/specification/2025-03-26/server/utilities/pagination.md
@@ -17,7 +17,8 @@ data sets.
 Pagination in MCP uses an opaque cursor-based approach, instead of numbered pages.
 
 - The **cursor** is an opaque string token, representing a position in the result set
-- **Page size** is determined by the server, and clients **MUST NOT** assume a fixed page size
+- **Page size** is determined by the server, and clients **MUST NOT** assume a fixed page
+  size
 
 ## Response Format
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
https://github.com/modelcontextprotocol/specification/issues/194
Clarifies the requirements language for server pagination to conform to RFC2119.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Validated schema, generated json, and tested in documentation server

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
