### PR TITLE
[Fix]: Page not found for contributing page

### DIFF
--- a/docs/specification/2024-11-05/_index.md
+++ b/docs/specification/2024-11-05/_index.md
@@ -132,4 +132,4 @@ Explore the detailed specification for each protocol component:
 {{< card link="basic" title="Base Protocol" icon="code" >}}
 {{< card link="server" title="Server Features" icon="server" >}}
 {{< card link="client" title="Client Features" icon="user" >}}
-{{< card link="contributing" title="Contributing" icon="pencil" >}} {{< /cards >}}
+{{< card link="../contributing" title="Contributing" icon="pencil" >}} {{< /cards >}}

--- a/docs/specification/2025-03-26/_index.md
+++ b/docs/specification/2025-03-26/_index.md
@@ -136,4 +136,4 @@ Explore the detailed specification for each protocol component:
 {{< card link="basic" title="Base Protocol" icon="code" >}}
 {{< card link="server" title="Server Features" icon="server" >}}
 {{< card link="client" title="Client Features" icon="user" >}}
-{{< card link="contributing" title="Contributing" icon="pencil" >}} {{< /cards >}}
+{{< card link="../contributing" title="Contributing" icon="pencil" >}} {{< /cards >}}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
- Correction in the redirection link of `Contributing` card for both the tabs.

## Motivation and Context
- When user clicks `Contributing` card while being on [2024-11-05](https://spec.modelcontextprotocol.io/specification/2024-11-05) tab or [2025-03-26](https://spec.modelcontextprotocol.io/specification/2025-03-26/), It gets redirected to `404 - This page could not be found`.

## How Has This Been Tested?
- Locally, using Hugo to ensure that contributing page is correctly redirected.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

